### PR TITLE
Remove `q` from required parameters

### DIFF
--- a/src/Queries/MonsterQuery.php
+++ b/src/Queries/MonsterQuery.php
@@ -56,8 +56,6 @@ class MonsterQuery extends AbstractQuery
      */
     protected function requiredAttributes()
     {
-        return [
-            'q',
-        ];
+        return [];
     }
 }


### PR DESCRIPTION
the `q` parameter is optional by the API.

try clicking the endpoint: http://rss.jobsearch.monster.com/rssquery.ashx